### PR TITLE
 fix(ui): make the action logger visible on smaller screen 

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "react-inspector": "^2.0.0",
-    "react-split-pane": "^0.1.63",
+    "react-split-pane": "^0.1.68",
     "styled-components": "^2.0.1",
     "styled-normalize": "^2.0.0"
   },

--- a/src/ui/action-logger.js
+++ b/src/ui/action-logger.js
@@ -10,9 +10,9 @@ const Container = styled.div`
   background-color: #fff;
   border: solid 1px #E4E4E4;
   border-radius: 5px;
-  height: calc(100% - 10px);
   margin: 0 10px 10px 0;
   overflow: hidden;
+  width: 100%;
 `;
 
 const Title = styled.div`

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -80,15 +80,19 @@ const StoryContainer = styled.div`
   border: solid 1px #E4E4E4;
   border-radius: 5px;
   margin: 10px 10px 0 0;
-  width: 100%;
+  height: calc(100% - 10px);
   overflow: scroll;
 `;
+
+const paneStyle = {
+  overflow: 'scroll',
+};
 
 const DevNovelUI = ({ devNovelInstance }: { devNovelInstance: Object }) =>
   <UIWrapper>
     <SplitPane split="vertical" minSize={250}>
       <Sidebar devNovelInstance={devNovelInstance} />
-      <SplitPane split="horizontal" minSize={750}>
+      <SplitPane split="horizontal" defaultSize={200} primary="second" paneStyle={paneStyle}>
         <StoryContainer id="story-container" />
         <ActionLogger devNovelInstance={devNovelInstance} />
       </SplitPane>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@types/inline-style-prefixer@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/inline-style-prefixer/-/inline-style-prefixer-3.0.1.tgz#8541e636b029124b747952e9a28848286d2b5bf6"
+
+"@types/react@^16.0.18":
+  version "16.0.18"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.18.tgz#c08eea79ada55bf10b5353e18c21797dd17afa23"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -887,9 +895,9 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bowser@^1.6.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.7.0.tgz#169de4018711f994242bff9a8009e77a1f35e003"
+bowser@^1.7.3:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.8.1.tgz#49785777e7302febadb1a5b71d9a646520ed310d"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -1089,9 +1097,9 @@ css-color-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
 
-css-in-js-utils@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-1.0.3.tgz#9ac7e02f763cf85d94017666565ed68a5b5f3215"
+css-in-js-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz#5af1dd70f4b06b331f48d22a3d86e0786c0b9435"
   dependencies:
     hyphenate-style-name "^1.0.2"
 
@@ -1743,12 +1751,12 @@ ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
-inline-style-prefixer@^3.0.2:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-3.0.6.tgz#b27fe309b4168a31eaf38c8e8c60ab9e7c11731f"
+inline-style-prefixer@^3.0.6:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz#8551b8e5b4d573244e66a34b04f7d32076a2b534"
   dependencies:
-    bowser "^1.6.0"
-    css-in-js-utils "^1.0.3"
+    bowser "^1.7.3"
+    css-in-js-utils "^2.0.0"
 
 inquirer@^3.0.6:
   version "3.1.1"
@@ -2457,7 +2465,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8:
+prop-types@^15.5.10, prop-types@^15.5.4:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -2513,12 +2521,14 @@ react-inspector@^2.0.0:
     babel-runtime "^6.23.0"
     is-dom "^1.0.9"
 
-react-split-pane@^0.1.63:
-  version "0.1.63"
-  resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.63.tgz#fadb3960cc659911dd05ffbc88acee4be9f53583"
+react-split-pane@^0.1.68:
+  version "0.1.68"
+  resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.68.tgz#a4ed40b0e77f0578cb6c9f9e65edd32726e4b16a"
   dependencies:
-    inline-style-prefixer "^3.0.2"
-    prop-types "^15.5.8"
+    "@types/inline-style-prefixer" "^3.0.0"
+    "@types/react" "^16.0.18"
+    inline-style-prefixer "^3.0.6"
+    prop-types "^15.5.10"
     react-style-proptype "^3.0.0"
 
 react-style-proptype@^3.0.0:


### PR DESCRIPTION
Before when the content was big and the screen window small, it was not possible to see the action logger. Now you can:

![2017-10-27 17 38 42](https://user-images.githubusercontent.com/393765/32112542-d9629948-bb3d-11e7-9f28-930a804b8340.gif)
